### PR TITLE
Add beer drunk status tracking functionality

### DIFF
--- a/beer_analyzer/BeerModels.swift
+++ b/beer_analyzer/BeerModels.swift
@@ -44,6 +44,8 @@ struct BeerRecord: Codable, Identifiable {
     let userId: String // どのユーザーが記録したか
     // MARK: - 画像URLを追加
     let imageUrl: String?
+    // MARK: - 飲んだかどうかのフラグを追加
+    let hasDrunk: Bool
 
     // Encodable のカスタムエンコーダ (Firestoreに保存する際に必要)
     func encode(to encoder: Encoder) throws {
@@ -58,10 +60,11 @@ struct BeerRecord: Codable, Identifiable {
         try container.encode(timestamp, forKey: .timestamp)
         try container.encode(userId, forKey: .userId)
         try container.encode(imageUrl, forKey: .imageUrl)
+        try container.encode(hasDrunk, forKey: .hasDrunk)
     }
 
     // FirebaseのaddDocなどで使用するためのinit (FireStoreServiceで使用)
-    init(analysisResult: BeerAnalysisResult, userId: String, timestamp: Date, imageUrl: String) {
+    init(analysisResult: BeerAnalysisResult, userId: String, timestamp: Date, imageUrl: String, hasDrunk: Bool = false) {
         self.beerName = analysisResult.beerName
         self.brand = analysisResult.brand
         self.manufacturer = analysisResult.manufacturer
@@ -72,6 +75,7 @@ struct BeerRecord: Codable, Identifiable {
         self.userId = userId
         self.timestamp = timestamp
         self.imageUrl = imageUrl
+        self.hasDrunk = hasDrunk
     }
 }
 

--- a/beer_analyzer/Views/BeerEditView.swift
+++ b/beer_analyzer/Views/BeerEditView.swift
@@ -19,6 +19,7 @@ struct BeerEditView: View {
     @State private var abv: String
     @State private var capacity: String
     @State private var hops: String
+    @State private var hasDrunk: Bool
     
     // サービスへのアクセス
     @EnvironmentObject var firestoreService: FirestoreService
@@ -39,6 +40,7 @@ struct BeerEditView: View {
         _abv = State(initialValue: beer.abv)
         _capacity = State(initialValue: beer.capacity)
         _hops = State(initialValue: beer.hops)
+        _hasDrunk = State(initialValue: beer.hasDrunk)
     }
 
     var body: some View {
@@ -92,6 +94,45 @@ struct BeerEditView: View {
                     }
                     .autocorrectionDisabled() // 自動修正を無効にする（ビール名などに不要な場合）
                     .textInputAutocapitalization(.never) // 自動大文字化を無効にする
+
+                    // MARK: - 飲んだかどうかのトグル
+                    VStack(alignment: .leading, spacing: 8) {
+                        HStack {
+                            Text("飲んだかどうか")
+                                .font(.headline)
+                                .fontWeight(.semibold)
+                            Spacer()
+                            Toggle("", isOn: $hasDrunk)
+                                .toggleStyle(SwitchToggleStyle())
+                        }
+                        .padding(.horizontal)
+                        
+                        if hasDrunk {
+                            HStack {
+                                Image(systemName: "checkmark.circle.fill")
+                                    .foregroundColor(.green)
+                                Text("飲みました！🍺")
+                                    .font(.subheadline)
+                                    .foregroundColor(.green)
+                                Spacer()
+                            }
+                            .padding(.horizontal)
+                        } else {
+                            HStack {
+                                Image(systemName: "circle")
+                                    .foregroundColor(.gray)
+                                Text("まだ飲んでいません")
+                                    .font(.subheadline)
+                                    .foregroundColor(.gray)
+                                Spacer()
+                            }
+                            .padding(.horizontal)
+                        }
+                    }
+                    .padding(.vertical, 8)
+                    .background(Color.gray.opacity(0.1))
+                    .cornerRadius(10)
+                    .padding(.horizontal)
 
                     // MARK: - 保存ボタン
                     Button {
@@ -174,7 +215,8 @@ struct BeerEditView: View {
                     ),
                     userId: originalBeer.userId, // UserIDは元のまま
                     timestamp: originalBeer.timestamp, // タイムスタンプは元のまま
-                    imageUrl: originalBeer.imageUrl ?? ""
+                    imageUrl: originalBeer.imageUrl ?? "",
+                    hasDrunk: hasDrunk // 飲んだかどうかの状態を反映
                 )
                 
                 try await firestoreService.updateBeer(documentId: originalBeer.id ?? "", beer: updatedBeer)

--- a/beer_analyzer/Views/BeerRecordRow.swift
+++ b/beer_analyzer/Views/BeerRecordRow.swift
@@ -55,7 +55,24 @@ struct BeerRecordRow: View {
         .frame(maxWidth: .infinity, alignment: .leading)
         .padding(.vertical, 8)
         .padding(.horizontal, 12)
-        .background(Color.white)
+        .background(
+            ZStack {
+                Color.white
+                // 飲んだビールの場合は背景にビール絵文字を表示
+                if beer.hasDrunk {
+                    VStack {
+                        HStack {
+                            Spacer()
+                            Text("🍺")
+                                .font(.system(size: 40))
+                                .opacity(0.3)
+                                .offset(x: -10, y: -10)
+                        }
+                        Spacer()
+                    }
+                }
+            }
+        )
         .cornerRadius(10)
         .shadow(color: Color.black.opacity(0.1), radius: 2, x: 0, y: 1)
         .contentShape(Rectangle())


### PR DESCRIPTION
## Summary
- Add drunk status tracking to beer records with visual indicators in the list
- Implement toggle control in edit view for marking beers as consumed

## Features Added
- **Drunk Status Field**: New `hasDrunk` boolean field in BeerRecord model
- **Edit Interface**: Toggle switch in BeerEditView to mark/unmark beers as drunk
- **Visual Indicators**: Beer emoji (🍺) background for consumed beers in list
- **Status Feedback**: Green checkmark for drunk, gray circle for not drunk

## Test Plan
- [ ] Verify drunk status toggle appears in beer edit screen
- [ ] Test marking beer as drunk shows green checkmark and "飲みました！🍺"
- [ ] Test unmarking beer shows gray circle and "まだ飲んでいません"
- [ ] Confirm drunk beers display 🍺 emoji background in records list
- [ ] Verify status persists after saving and reloading

🤖 Generated with [Claude Code](https://claude.ai/code)