### PR TITLE
Improve beer emoji display positioning and size

### DIFF
--- a/beer_analyzer/Views/BeerRecordRow.swift
+++ b/beer_analyzer/Views/BeerRecordRow.swift
@@ -61,14 +61,15 @@ struct BeerRecordRow: View {
                 // 飲んだビールの場合は背景にビール絵文字を表示
                 if beer.hasDrunk {
                     VStack {
+                        Spacer()
                         HStack {
                             Spacer()
                             Text("🍺")
-                                .font(.system(size: 40))
-                                .opacity(0.3)
-                                .offset(x: -10, y: -10)
+                                .font(.system(size: 60))
+                                .opacity(0.2)
+                                .padding(.trailing, 8)
+                                .padding(.bottom, 8)
                         }
-                        Spacer()
                     }
                 }
             }


### PR DESCRIPTION
## Summary
- Enhance beer emoji display for consumed beer records with better positioning and larger size
- Move emoji from top-right to bottom-right corner for improved visual hierarchy

## Changes Made
- **Position**: Moved beer emoji from top-right to bottom-right corner
- **Size**: Increased emoji size from 40pt to 60pt for better visibility
- **Layout**: Added proper padding (8pt) to prevent emoji cutoff
- **Opacity**: Adjusted to 0.2 for optimal content readability
- **Visibility**: Ensured emoji is fully contained within card boundaries

## Test Plan
- [ ] Verify beer emoji appears in bottom-right corner of consumed beer items
- [ ] Confirm emoji is larger and more visible than before
- [ ] Check emoji doesn't interfere with text content readability
- [ ] Ensure emoji is fully visible without being cut off

🤖 Generated with [Claude Code](https://claude.ai/code)