### PR TITLE
Add beer website link functionality with in-app browser

### DIFF
--- a/beer_analyzer/BeerModels.swift
+++ b/beer_analyzer/BeerModels.swift
@@ -46,6 +46,8 @@ struct BeerRecord: Codable, Identifiable {
     let imageUrl: String?
     // MARK: - 飲んだかどうかのフラグを追加
     let hasDrunk: Bool
+    // MARK: - 公式サイトURLを追加
+    let websiteUrl: String?
 
     // Encodable のカスタムエンコーダ (Firestoreに保存する際に必要)
     func encode(to encoder: Encoder) throws {
@@ -61,10 +63,11 @@ struct BeerRecord: Codable, Identifiable {
         try container.encode(userId, forKey: .userId)
         try container.encode(imageUrl, forKey: .imageUrl)
         try container.encode(hasDrunk, forKey: .hasDrunk)
+        try container.encode(websiteUrl, forKey: .websiteUrl)
     }
 
     // FirebaseのaddDocなどで使用するためのinit (FireStoreServiceで使用)
-    init(analysisResult: BeerAnalysisResult, userId: String, timestamp: Date, imageUrl: String, hasDrunk: Bool = false) {
+    init(analysisResult: BeerAnalysisResult, userId: String, timestamp: Date, imageUrl: String, hasDrunk: Bool = false, websiteUrl: String? = nil) {
         self.beerName = analysisResult.beerName
         self.brand = analysisResult.brand
         self.manufacturer = analysisResult.manufacturer
@@ -76,6 +79,7 @@ struct BeerRecord: Codable, Identifiable {
         self.timestamp = timestamp
         self.imageUrl = imageUrl
         self.hasDrunk = hasDrunk
+        self.websiteUrl = websiteUrl
     }
 }
 

--- a/beer_analyzer/Views/BeerEditView.swift
+++ b/beer_analyzer/Views/BeerEditView.swift
@@ -20,6 +20,7 @@ struct BeerEditView: View {
     @State private var capacity: String
     @State private var hops: String
     @State private var hasDrunk: Bool
+    @State private var websiteUrl: String
     
     // サービスへのアクセス
     @EnvironmentObject var firestoreService: FirestoreService
@@ -41,6 +42,7 @@ struct BeerEditView: View {
         _capacity = State(initialValue: beer.capacity)
         _hops = State(initialValue: beer.hops)
         _hasDrunk = State(initialValue: beer.hasDrunk)
+        _websiteUrl = State(initialValue: beer.websiteUrl ?? "")
     }
 
     var body: some View {
@@ -90,6 +92,11 @@ struct BeerEditView: View {
                             .padding(.horizontal)
                         TextField("ホップ", text: $hops)
                             .textFieldStyle(RoundedBorderTextFieldStyle())
+                            .padding(.horizontal)
+                        TextField("公式サイトURL (任意)", text: $websiteUrl)
+                            .textFieldStyle(RoundedBorderTextFieldStyle())
+                            .keyboardType(.URL)
+                            .autocapitalization(.none)
                             .padding(.horizontal)
                     }
                     .autocorrectionDisabled() // 自動修正を無効にする（ビール名などに不要な場合）
@@ -216,7 +223,8 @@ struct BeerEditView: View {
                     userId: originalBeer.userId, // UserIDは元のまま
                     timestamp: originalBeer.timestamp, // タイムスタンプは元のまま
                     imageUrl: originalBeer.imageUrl ?? "",
-                    hasDrunk: hasDrunk // 飲んだかどうかの状態を反映
+                    hasDrunk: hasDrunk, // 飲んだかどうかの状態を反映
+                    websiteUrl: websiteUrl.isEmpty ? nil : websiteUrl // 空文字の場合はnilに変換
                 )
                 
                 try await firestoreService.updateBeer(documentId: originalBeer.id ?? "", beer: updatedBeer)

--- a/beer_analyzer/Views/BeerRecordRow.swift
+++ b/beer_analyzer/Views/BeerRecordRow.swift
@@ -6,10 +6,13 @@
 
 import SwiftUI
 import Kingfisher
+import SafariServices
 
 struct BeerRecordRow: View {
     let beer: BeerRecord
     var onDelete: (String) -> Void
+    
+    @State private var showingSafari = false
 
     var body: some View {
         HStack(alignment: .top, spacing: 10) {
@@ -50,6 +53,27 @@ struct BeerRecordRow: View {
                     .font(.caption)
                     .foregroundColor(.gray)
             }
+            
+            // MARK: - 公式サイトリンクアイコン
+            VStack {
+                if let websiteUrlString = beer.websiteUrl, 
+                   !websiteUrlString.isEmpty,
+                   let _ = URL(string: websiteUrlString) {
+                    Button {
+                        showingSafari = true
+                    } label: {
+                        Image(systemName: "link.circle.fill")
+                            .font(.system(size: 24))
+                            .foregroundColor(.blue)
+                            .background(Color.white)
+                            .clipShape(Circle())
+                            .shadow(radius: 2)
+                    }
+                    .padding(.top, 4)
+                }
+                Spacer()
+            }
+            
             Spacer()
         }
         .frame(maxWidth: .infinity, alignment: .leading)
@@ -86,5 +110,25 @@ struct BeerRecordRow: View {
                 Label("削除", systemImage: "trash")
             }
         }
+        .sheet(isPresented: $showingSafari) {
+            if let websiteUrlString = beer.websiteUrl,
+               let url = URL(string: websiteUrlString) {
+                SafariView(url: url)
+                    .ignoresSafeArea()
+            }
+        }
+    }
+}
+
+// MARK: - SafariView（アプリ内ブラウザ）
+struct SafariView: UIViewControllerRepresentable {
+    let url: URL
+    
+    func makeUIViewController(context: Context) -> SFSafariViewController {
+        return SFSafariViewController(url: url)
+    }
+    
+    func updateUIViewController(_ uiViewController: SFSafariViewController, context: Context) {
+        // 更新処理は不要
     }
 }


### PR DESCRIPTION
## Summary
- Add official website link functionality to beer records with in-app browser integration
- Allow users to save and access brewery/beer official websites directly from the app

## Features Added
- **Website URL Field**: New `websiteUrl` optional field in BeerRecord model
- **URL Input**: Text field in BeerEditView for entering official website URLs
- **Link Icon**: Blue link icon (🔗) displayed for beers with valid website URLs
- **In-App Browser**: SafariServices integration for seamless web browsing
- **URL Validation**: Proper URL handling and empty string conversion

## Technical Implementation
- **Data Model**: Added `websiteUrl: String?` to BeerRecord with Firestore encoding
- **UI Components**: URL-optimized keyboard and conditional icon display
- **Safari Integration**: UIViewControllerRepresentable wrapper for SFSafariViewController
- **User Experience**: Sheet presentation with full-screen browser view

## Test Plan
- [ ] Verify URL input field appears in beer edit screen
- [ ] Test URL keyboard optimization and input validation
- [ ] Confirm link icon shows only for beers with valid URLs
- [ ] Test in-app browser opens when tapping link icon
- [ ] Verify browser dismisses properly and returns to app
- [ ] Check URL persistence in Firestore database

🤖 Generated with [Claude Code](https://claude.ai/code)