### PR TITLE
Improve website link button usability and visual design

### DIFF
--- a/beer_analyzer/Views/BeerRecordRow.swift
+++ b/beer_analyzer/Views/BeerRecordRow.swift
@@ -62,13 +62,24 @@ struct BeerRecordRow: View {
                     Button {
                         showingSafari = true
                     } label: {
-                        Image(systemName: "link.circle.fill")
-                            .font(.system(size: 24))
-                            .foregroundColor(.blue)
-                            .background(Color.white)
-                            .clipShape(Circle())
-                            .shadow(radius: 2)
+                        VStack(spacing: 4) {
+                            Image(systemName: "link.circle.fill")
+                                .font(.system(size: 30))
+                                .foregroundColor(.blue)
+                            Text("公式サイト")
+                                .font(.caption2)
+                                .foregroundColor(.blue)
+                                .fontWeight(.medium)
+                        }
+                        .padding(.horizontal, 12)
+                        .padding(.vertical, 8)
+                        .background(
+                            RoundedRectangle(cornerRadius: 12)
+                                .fill(Color.blue.opacity(0.1))
+                                .stroke(Color.blue.opacity(0.3), lineWidth: 1)
+                        )
                     }
+                    .buttonStyle(PlainButtonStyle())
                     .padding(.top, 4)
                 }
                 Spacer()


### PR DESCRIPTION
## Summary
- Enhance website link button design for better usability and visual clarity
- Increase tap area and improve visual feedback for easier user interaction

## Improvements Made
- **Larger Icon**: Increased link icon size from 24pt to 30pt for better visibility
- **Clear Labeling**: Added "公式サイト" text label to clarify button function
- **Enhanced Tap Area**: Larger interactive area with proper padding for easier tapping
- **Visual Design**: Blue background with rounded corners and subtle border
- **Better UX**: PlainButtonStyle prevents default styling interference

## Visual Changes
- **Background**: Light blue background (opacity 0.1) with rounded corners
- **Border**: Subtle blue border (opacity 0.3) for definition
- **Typography**: Caption2 font with medium weight for readability
- **Spacing**: Proper vertical and horizontal padding for comfortable interaction

## User Experience Impact
- **Easier Tapping**: Larger target area reduces misclicks
- **Clear Purpose**: Text label makes function immediately obvious
- **Professional Look**: Consistent with modern iOS design patterns
- **Accessibility**: Better contrast and larger touch targets

## Test Plan
- [ ] Verify larger tap area works correctly on various device sizes
- [ ] Test button appears only for beers with valid website URLs
- [ ] Confirm in-app Safari browser still opens properly when tapped
- [ ] Check visual consistency across different beer record items
- [ ] Validate accessibility improvements for users with motor difficulties

🤖 Generated with [Claude Code](https://claude.ai/code)